### PR TITLE
Use pushd/popd instead of cd

### DIFF
--- a/cef/fetch-required-files.sh
+++ b/cef/fetch-required-files.sh
@@ -14,6 +14,6 @@ if [[ ! -f "v8_context_snapshot.bin" ]]; then
     mv ${CEF_FOLDER}/Release/* ../
     mv ${CEF_FOLDER}/Resources/* ../
     echo 'Cleaning up'
-    popd
+    popd > /dev/null
     rm -rf cef-project
 fi

--- a/cef/fetch-required-files.sh
+++ b/cef/fetch-required-files.sh
@@ -8,12 +8,12 @@ if [[ ! -f "v8_context_snapshot.bin" ]]; then
     mkdir 'cef-project' &> /dev/null
     echo 'Fetching required CEF binaries'
     curl -ocef-project/tmp.tar.bz2 "${CEF_URL}" &> /dev/null
-    cd cef-project
+    pushd cef-project > /dev/null
     echo 'Extracting and moving'
     tar xf tmp.tar.bz2
     mv ${CEF_FOLDER}/Release/* ../
     mv ${CEF_FOLDER}/Resources/* ../
     echo 'Cleaning up'
-    cd ..
+    popd
     rm -rf cef-project
 fi


### PR DESCRIPTION
CD is using the internal directory stack, so it'll overwrite the `cd -` call.

pushd and popd use a custom directory stack and traverse it instead, keeping the cd directory stack intact